### PR TITLE
feat: add vercel deployment configuration

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -129,13 +129,41 @@ git push -u origin main
 ## 🌐 部署選項
 
 ### Vercel（推薦）
-```bash
-# 安裝 Vercel CLI
-npm i -g vercel
 
-# 部署
+本專案已提供以下 Vercel 專用設定：
+
+- `vercel.json`：指定使用 Vite 建置、SPA 路由轉址與輸出目錄。
+- `api/[[...slug]].js`：將現有的 Node.js API 轉換為 Vercel Serverless Function，網址路徑為 `/api/*`。
+- 調整後的 `src/api/client.js`：在生產環境自動呼叫同網域的 `/api` 端點。
+
+#### 1. 安裝並登入 Vercel CLI
+```bash
+npm i -g vercel
+vercel login
+```
+
+#### 2. 連結專案
+```bash
+vercel link
+```
+
+#### 3. 設定環境變數（建議）
+```bash
+# 供後端簽發 JWT 使用
+vercel env add JWT_SECRET
+
+# （選用）自訂存放資料檔案路徑，預設會使用 /tmp/data/db.json
+vercel env add DEBTWISE_DB_FILE
+```
+
+> 提示：若想沿用預設設定，可跳過 `DEBTWISE_DB_FILE` 並在 Vercel 專案設定中將路徑設為 `/tmp/data/db.json` 或其他可讀寫的位置。
+
+#### 4. 部署
+```bash
 vercel --prod
 ```
+
+部署完成後可於 `https://<your-project>.vercel.app` 觀看前端，並透過 `https://<your-project>.vercel.app/api/...` 使用 API。
 
 ### Netlify
 ```bash

--- a/api/[[...slug]].js
+++ b/api/[[...slug]].js
@@ -1,0 +1,23 @@
+import { createRequestHandler } from '../src/app.js';
+
+const handler = createRequestHandler();
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default async function vercelHandler(req, res) {
+  const originalUrl = req.url || '/';
+  if (originalUrl.startsWith('/api')) {
+    const nextUrl = originalUrl.slice(4) || '/';
+    req.url = nextUrl.startsWith('/') ? nextUrl : `/${nextUrl}`;
+  }
+
+  try {
+    await handler(req, res);
+  } finally {
+    req.url = originalUrl;
+  }
+}

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,4 +1,6 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:4000';
+const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL ||
+  (import.meta.env.DEV ? 'http://localhost:4000' : '/api');
 
 class ApiError extends Error {
   constructor(message, status, details) {

--- a/src/app.js
+++ b/src/app.js
@@ -5,16 +5,26 @@ import Router from './http/router.js';
 import createServices from './services/index.js';
 import registerRoutes from './routes/index.js';
 
-function createServer() {
+function buildRouterContext() {
   const db = new Database();
   const baseContext = { config, db };
   const services = createServices(baseContext);
-  const routerContext = { ...baseContext, services };
+  return { ...baseContext, services };
+}
+
+function createRequestHandler() {
+  const routerContext = buildRouterContext();
   const router = new Router(routerContext);
   registerRoutes(router, routerContext);
-  return http.createServer((req, res) => router.handle(req, res));
+  return (req, res) => router.handle(req, res);
+}
+
+function createServer() {
+  const handler = createRequestHandler();
+  return http.createServer((req, res) => handler(req, res));
 }
 
 export {
   createServer,
+  createRequestHandler,
 };

--- a/src/storage/database.js
+++ b/src/storage/database.js
@@ -8,8 +8,12 @@ const DEFAULT_DATA = {
   reminders: [],
 };
 
+const DEFAULT_STORAGE_PATH = process.env.DEBTWISE_DB_FILE
+  ? process.env.DEBTWISE_DB_FILE
+  : path.join(process.env.VERCEL ? '/tmp' : process.cwd(), 'data', 'db.json');
+
 class Database {
-  constructor(filePath = path.join(process.cwd(), 'data', 'db.json')) {
+  constructor(filePath = DEFAULT_STORAGE_PATH) {
     this.filePath = filePath;
     this.ensureStorage();
     this.data = this.read();

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "framework": "vite",
+  "buildCommand": "npm run build",
+  "installCommand": "npm install",
+  "devCommand": "npm run dev",
+  "outputDirectory": "dist",
+  "rewrites": [
+    {
+      "source": "/(?!api)(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Vercel configuration file and serverless entry point for the Node API
- reuse the existing router as a request handler so Vercel functions can serve the backend
- update documentation and client defaults so the SPA works when deployed to Vercel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd8f3935fc832e951a601ccb7bd091