### PR TITLE
Enhance Supabase integration and add smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ VITE_APP_VERSION="1.0.0"
 # VITE_API_BASE_URL=https://api.debtwise.ai
 # VITE_API_TIMEOUT=10000
 
+# Supabase 配置
+# 請填入 Supabase 專案的 URL 與匿名金鑰
+VITE_SUPABASE_URL="https://pyeoexgfgsnpsgkpwmww.supabase.co"
+VITE_SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InB5ZW9leGdmZ3NucHNna3B3bXd3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgzMzYzNDUsImV4cCI6MjA3MzkxMjM0NX0.RCjVzfhODSd-kgeB_mD4InaNDDJBU1Ele07oQNWhQbA"
+
 # 第三方服務配置（未來使用）
 # VITE_GOOGLE_ANALYTICS_ID=G-XXXXXXXXXX
 # VITE_SENTRY_DSN=https://xxx@sentry.io/xxx

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.0",

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,0 +1,54 @@
+async function main() {
+  try {
+    await import('dotenv/config');
+  } catch (error) {
+    if ((error as { code?: string }).code !== 'ERR_MODULE_NOT_FOUND') {
+      console.warn('[smoke] 無法載入 dotenv，請確認是否已安裝相依套件。', error);
+    }
+  }
+
+  const { supabase } = await import('../src/services/supabaseClient');
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError) {
+    throw authError;
+  }
+
+  if (!user) {
+    throw new Error('尚未登入，請先使用 Supabase Auth 登入後再執行測試。');
+  }
+
+  const { data: debt, error } = await supabase
+    .from('debts')
+    .insert([
+      {
+        user_id: user.id,
+        name: '測試債務',
+        balance: 10000,
+        original_amount: 10000,
+        interest_rate: 10,
+        minimum_payment: 1000,
+        due_date: null,
+        debt_type: 'other',
+        status: 'active',
+        notes: '由 smoke 測試腳本建立',
+      },
+    ])
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  console.log('OK 新增債務：', debt?.id);
+}
+
+main().catch((error) => {
+  console.error('[smoke] 測試失敗：', error);
+  process.exitCode = 1;
+});

--- a/src/hooks/useDebts.ts
+++ b/src/hooks/useDebts.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import type { Debt } from '../types/db';
+import { listDebts } from '../services/debts';
+
+type UseDebtsResult = {
+  data: Debt[];
+  loading: boolean;
+  error: Error | null;
+  setData: Dispatch<SetStateAction<Debt[]>>;
+};
+
+export function useDebts(): UseDebtsResult {
+  const [data, setData] = useState<Debt[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    (async () => {
+      try {
+        setLoading(true);
+        const results = await listDebts();
+        if (isMounted) {
+          setData(results);
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err instanceof Error ? err : new Error('Failed to load debts.'));
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { data, loading, error, setData };
+}

--- a/src/pages/DebtsPage.tsx
+++ b/src/pages/DebtsPage.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { supabase } from '../services/supabaseClient';
+import { useDebts } from '../hooks/useDebts';
+import { createDebt } from '../services/debts';
+import type { Debt, DebtStatus, DebtType } from '../types/db';
+
+export default function DebtsPage() {
+  const { data: debts, loading, error, setData } = useDebts();
+  const [name, setName] = useState('');
+  const [balance, setBalance] = useState<number>(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const onAdd = async () => {
+    if (!name.trim()) {
+      setFormError('請輸入債務名稱');
+      return;
+    }
+
+    if (balance <= 0) {
+      setFormError('請輸入有效的債務餘額');
+      return;
+    }
+
+    setFormError(null);
+    setSubmitting(true);
+
+    try {
+      const {
+        data: { user },
+        error: authError,
+      } = await supabase.auth.getUser();
+
+      if (authError) {
+        throw authError;
+      }
+
+      if (!user) {
+        throw new Error('請先登入帳號');
+      }
+
+      const payload: Omit<Debt, 'id' | 'created_at' | 'updated_at'> = {
+        user_id: user.id,
+        name: name.trim(),
+        balance,
+        original_amount: balance,
+        interest_rate: 0,
+        minimum_payment: 0,
+        due_date: null,
+        debt_type: 'other' as DebtType,
+        status: 'active' as DebtStatus,
+        notes: null,
+      };
+
+      const created = await createDebt(payload);
+      setData((prev) => [created, ...prev]);
+      setName('');
+      setBalance(0);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : '新增債務時發生錯誤';
+      setFormError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return <div>Loading…</div>;
+  }
+
+  if (error) {
+    const message = error instanceof Error ? error.message : '載入債務資料時發生錯誤';
+    return <div>Oops: {message}</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <input
+          className="border px-2 py-1 rounded"
+          placeholder="債務名稱"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          disabled={submitting}
+        />
+        <input
+          className="border px-2 py-1 rounded"
+          placeholder="餘額"
+          type="number"
+          value={balance || ''}
+          onChange={(event) => setBalance(Number(event.target.value) || 0)}
+          disabled={submitting}
+        />
+        <button
+          className="px-3 py-1 bg-indigo-600 text-white rounded disabled:opacity-50"
+          onClick={onAdd}
+          disabled={submitting}
+        >
+          新增
+        </button>
+      </div>
+
+      {formError ? <div className="text-sm text-red-600">{formError}</div> : null}
+
+      <ul className="space-y-2">
+        {debts.map((debt) => (
+          <li key={debt.id} className="border rounded p-3">
+            <div className="font-medium">{debt.name}</div>
+            <div className="text-sm text-gray-600">餘額：{debt.balance}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,22 @@
+import type { AuthError, AuthResponse, Session, User } from '@supabase/supabase-js';
+import { supabase } from './supabaseClient';
+
+export const signInWithOtp = async (email: string): Promise<AuthResponse> =>
+  supabase.auth.signInWithOtp({ email, options: { shouldCreateUser: true } });
+
+export const signInWithPassword = async (
+  email: string,
+  password: string
+): Promise<AuthResponse> =>
+  supabase.auth.signInWithPassword({ email, password });
+
+export const signOut = () => supabase.auth.signOut();
+
+export const getCurrentSession = (): Promise<{ data: { session: Session | null }; error: AuthError | null }> =>
+  supabase.auth.getSession();
+
+export const getCurrentUser = (): Promise<{ data: { user: User | null }; error: AuthError | null }> =>
+  supabase.auth.getUser();
+
+export const onAuthStateChange = (callback: Parameters<typeof supabase.auth.onAuthStateChange>[0]) =>
+  supabase.auth.onAuthStateChange(callback);

--- a/src/services/debts.ts
+++ b/src/services/debts.ts
@@ -1,0 +1,67 @@
+import { supabase } from './supabaseClient';
+import type { Debt } from '../types/db';
+
+export async function listDebts(): Promise<Debt[]> {
+  const { data, error } = await supabase
+    .from('debts')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as Debt[];
+}
+
+export async function createDebt(
+  input: Omit<Debt, 'id' | 'created_at' | 'updated_at'>
+): Promise<Debt> {
+  const timestamp = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('debts')
+    .insert([{ ...input, created_at: timestamp, updated_at: timestamp }])
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    throw new Error('Failed to create debt.');
+  }
+
+  return data as Debt;
+}
+
+export async function updateDebt(id: string, patch: Partial<Debt>): Promise<Debt> {
+  const updates = {
+    ...patch,
+    updated_at: new Date().toISOString(),
+  };
+  const { data, error } = await supabase
+    .from('debts')
+    .update(updates)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    throw new Error('Debt not found.');
+  }
+
+  return data as Debt;
+}
+
+export async function removeDebt(id: string): Promise<void> {
+  const { error } = await supabase.from('debts').delete().eq('id', id);
+
+  if (error) {
+    throw error;
+  }
+}

--- a/src/services/payments.ts
+++ b/src/services/payments.ts
@@ -1,0 +1,37 @@
+import { supabase } from './supabaseClient';
+import type { Payment } from '../types/db';
+
+export async function listPayments(debtId: string): Promise<Payment[]> {
+  const { data, error } = await supabase
+    .from('payments')
+    .select('*')
+    .eq('debt_id', debtId)
+    .order('payment_date', { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as Payment[];
+}
+
+export async function addPayment(
+  payment: Omit<Payment, 'id' | 'created_at'>
+): Promise<Payment> {
+  const timestamp = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('payments')
+    .insert([{ ...payment, created_at: timestamp }])
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    throw new Error('Failed to create payment.');
+  }
+
+  return data as Payment;
+}

--- a/src/services/reminders.ts
+++ b/src/services/reminders.ts
@@ -1,0 +1,36 @@
+import { supabase } from './supabaseClient';
+import type { Reminder } from '../types/db';
+
+export async function listMyReminders(): Promise<Reminder[]> {
+  const { data, error } = await supabase
+    .from('reminders')
+    .select('*')
+    .order('reminder_date', { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as Reminder[];
+}
+
+export async function createReminder(
+  reminder: Omit<Reminder, 'id' | 'created_at' | 'is_completed'>
+): Promise<Reminder> {
+  const timestamp = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('reminders')
+    .insert([{ ...reminder, is_completed: false, created_at: timestamp }])
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data) {
+    throw new Error('Failed to create reminder.');
+  }
+
+  return data as Reminder;
+}

--- a/src/services/supabaseClient.ts
+++ b/src/services/supabaseClient.ts
@@ -1,0 +1,46 @@
+import { createClient } from '@supabase/supabase-js';
+
+type EnvSource = Record<string, string | undefined>;
+
+const importMetaEnv =
+  typeof import.meta !== 'undefined' && typeof import.meta.env !== 'undefined'
+    ? (import.meta.env as EnvSource)
+    : undefined;
+
+const processEnv =
+  typeof globalThis !== 'undefined' &&
+  typeof (globalThis as { process?: { env?: EnvSource } }).process?.env !== 'undefined'
+    ? ((globalThis as { process?: { env?: EnvSource } }).process?.env as EnvSource)
+    : undefined;
+
+const envSources = [importMetaEnv, processEnv].filter(Boolean) as EnvSource[];
+
+const getEnvVar = (key: string) => {
+  for (const source of envSources) {
+    const value = source[key];
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const supabaseUrl = getEnvVar('VITE_SUPABASE_URL') ?? getEnvVar('SUPABASE_URL');
+const supabaseAnonKey =
+  getEnvVar('VITE_SUPABASE_ANON_KEY') ?? getEnvVar('SUPABASE_ANON_KEY');
+
+if (!supabaseUrl) {
+  throw new Error('Missing VITE_SUPABASE_URL environment variable.');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+    detectSessionInUrl: true,
+  },
+});

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,0 +1,71 @@
+export type MembershipType = 'free' | 'premium';
+export type DebtType =
+  | 'credit_card'
+  | 'auto_loan'
+  | 'student_loan'
+  | 'mortgage'
+  | 'personal_loan'
+  | 'medical_debt'
+  | 'other';
+export type DebtStatus = 'active' | 'paid_off' | 'closed';
+export type PaymentType = 'regular' | 'extra' | 'minimum' | 'final';
+export type StrategyType = 'snowball' | 'avalanche';
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  name?: string;
+  membership_type: MembershipType;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Debt {
+  id: string;
+  user_id: string;
+  name: string;
+  balance: number;
+  original_amount: number;
+  interest_rate: number;
+  minimum_payment: number;
+  due_date?: string | null;
+  debt_type: DebtType;
+  status: DebtStatus;
+  notes?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Payment {
+  id: string;
+  debt_id: string;
+  amount: number;
+  payment_date: string;
+  payment_type: PaymentType;
+  notes?: string | null;
+  created_at: string;
+}
+
+export interface Reminder {
+  id: string;
+  user_id: string;
+  debt_id?: string | null;
+  title: string;
+  message?: string | null;
+  reminder_type: 'due_date' | 'custom' | 'milestone' | 'strategy';
+  reminder_date: string;
+  is_completed: boolean;
+  created_at: string;
+}
+
+export interface StrategySimulation {
+  id: string;
+  user_id: string;
+  strategy_type: StrategyType;
+  extra_payment: number;
+  total_debt: number;
+  months_to_payoff?: number | null;
+  total_interest?: number | null;
+  simulation_data?: unknown;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- populate the Supabase environment example with the provided project URL and anon key for quick local setup
- make the shared Supabase client usable in both browser and Node contexts while auto-stamping CRUD helpers with timestamps and exposing auth utilities
- add a reusable OTP/password auth service, better error handling in the debts hook, and a smoke script to validate database writes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce36a31ea8832e8913d7253babb97b