### PR TITLE
Fix password input re-render to avoid autofill script crash

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -728,6 +728,7 @@ const DebtWiseAI = () => {
               </label>
               <div className="relative">
                 <input
+                  key={showPassword ? 'password-visible' : 'password-hidden'}
                   type={showPassword ? 'text' : 'password'}
                   value={authForm.password}
                   ref={passwordInputRef}


### PR DESCRIPTION
## Summary
- force the authentication password field to remount whenever the visibility toggle changes so browser autofill scripts re-evaluate the DOM node

## Testing
- npm run lint *(fails: ESLint 9 global install requires eslint.config.js; repository relies on local ESLint 8 but npm install is blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfec3c2a88832e85609dfbf0a52aa3