### PR TITLE
feat: add supabase auth flows and debt dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,81 @@
+/**
+ * Application root component wiring authentication flow with dashboard pages.
+ */
+import { useEffect, useMemo, useState } from 'react';
+
+import useAuth from './hooks/useAuth';
+import { upsertMyProfile } from './lib/db';
+import AuthGate from './pages/AuthGate';
+import DebtDashboard from './pages/DebtDashboard';
+
+const App = () => {
+  const { session, loading } = useAuth();
+  const [profileSyncing, setProfileSyncing] = useState(false);
+  const [profileError, setProfileError] = useState<string | null>(null);
+
+  const authenticatedUserId = useMemo(() => session?.user?.id ?? null, [session]);
+
+  useEffect(() => {
+    if (!authenticatedUserId) {
+      return;
+    }
+
+    let isActive = true;
+
+    const syncProfile = async () => {
+      setProfileSyncing(true);
+      setProfileError(null);
+
+      try {
+        await upsertMyProfile();
+      } catch (error) {
+        if (!isActive) return;
+
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to synchronize your profile with the database.';
+        setProfileError(message);
+      } finally {
+        if (!isActive) return;
+        setProfileSyncing(false);
+      }
+    };
+
+    syncProfile();
+
+    return () => {
+      isActive = false;
+    };
+  }, [authenticatedUserId]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-100 text-slate-700">
+        <p className="text-lg font-medium">Loading authentication state…</p>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return <AuthGate />;
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900">
+      {profileSyncing && (
+        <div className="bg-blue-50 px-4 py-3 text-sm text-blue-700">
+          正在同步您的檔案資料…
+        </div>
+      )}
+      {profileError && (
+        <div className="bg-red-50 px-4 py-3 text-sm text-red-700">
+          {profileError}
+        </div>
+      )}
+      <DebtDashboard />
+    </div>
+  );
+};
+
+export default App;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,60 @@
+/**
+ * React hook for managing Supabase authentication state.
+ *
+ * The hook retrieves the initial session and subscribes to future auth changes,
+ * ensuring components always have the latest session information.
+ */
+import { useEffect, useState } from 'react';
+import type { Session } from '@supabase/supabase-js';
+
+import supabase from '../lib/supabaseClient';
+
+export interface UseAuthResult {
+  session: Session | null;
+  loading: boolean;
+}
+
+const useAuth = (): UseAuthResult => {
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadSession = async () => {
+      try {
+        const { data, error } = await supabase.auth.getSession();
+        if (!isMounted) return;
+
+        if (error) {
+          console.error('Failed to get auth session', error);
+        }
+
+        setSession(data.session ?? null);
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadSession();
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      if (!isMounted) return;
+      setSession(newSession);
+      setLoading(false);
+    });
+
+    return () => {
+      isMounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return { session, loading };
+};
+
+export default useAuth;

--- a/src/hooks/useDebts.ts
+++ b/src/hooks/useDebts.ts
@@ -1,44 +1,150 @@
-import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
-import type { Debt } from '../types/db';
-import { listDebts } from '../services/debts';
+/**
+ * React hook that provides debt data with realtime updates.
+ *
+ * The hook listens to Supabase realtime changes on `debts` and `payments`
+ * tables, ensuring the returned data stays in sync with backend mutations.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-type UseDebtsResult = {
-  data: Debt[];
+import type {
+  CreateDebtPayload,
+  Debt,
+  VDebtProgress,
+} from '../lib/db';
+import {
+  createDebt as createDebtMutation,
+  listDebtProgress,
+  listDebts,
+  removeDebt as removeDebtMutation,
+} from '../lib/db';
+import supabase from '../lib/supabaseClient';
+
+export interface DebtRow extends Debt {
+  total_paid: string;
+  paid_percent: string;
+  remaining_balance?: string | null;
+  last_payment_date?: string | null;
+}
+
+export interface UseDebtsResult {
+  rows: DebtRow[];
   loading: boolean;
-  error: Error | null;
-  setData: Dispatch<SetStateAction<Debt[]>>;
+  refresh: () => Promise<void>;
+  createDebt: (payload: CreateDebtPayload) => Promise<Debt>;
+  removeDebt: (debtId: string) => Promise<void>;
+}
+
+const mergeDebtsWithProgress = (
+  debts: Debt[],
+  progresses: VDebtProgress[],
+): DebtRow[] => {
+  const progressMap = new Map<string, VDebtProgress>();
+  progresses.forEach((progress) => {
+    progressMap.set(progress.debt_id, progress);
+  });
+
+  return debts.map((debt) => {
+    const progress = progressMap.get(debt.id);
+    return {
+      ...debt,
+      total_paid: progress?.total_paid ?? '0',
+      paid_percent: progress?.paid_percent ?? '0',
+      remaining_balance: progress?.remaining_balance ?? null,
+      last_payment_date: progress?.last_payment_date ?? null,
+    };
+  });
 };
 
-export function useDebts(): UseDebtsResult {
-  const [data, setData] = useState<Debt[]>([]);
+const useDebts = (): UseDebtsResult => {
+  const [rows, setRows] = useState<DebtRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
+  const isMountedRef = useRef(true);
 
   useEffect(() => {
-    let isMounted = true;
-
-    (async () => {
-      try {
-        setLoading(true);
-        const results = await listDebts();
-        if (isMounted) {
-          setData(results);
-        }
-      } catch (err) {
-        if (isMounted) {
-          setError(err instanceof Error ? err : new Error('Failed to load debts.'));
-        }
-      } finally {
-        if (isMounted) {
-          setLoading(false);
-        }
-      }
-    })();
-
     return () => {
-      isMounted = false;
+      isMountedRef.current = false;
     };
   }, []);
 
-  return { data, loading, error, setData };
-}
+  const refresh = useCallback(async () => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const [debtsData, progressData] = await Promise.all([
+        listDebts(),
+        listDebtProgress(),
+      ]);
+      if (!isMountedRef.current) {
+        return;
+      }
+      setRows(mergeDebtsWithProgress(debtsData, progressData));
+    } catch (error) {
+      console.error('Failed to refresh debts data', error);
+      if (isMountedRef.current) {
+        setRows([]);
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    const channel = supabase
+      .channel('public:debts-payments')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'debts' },
+        () => {
+          void refresh();
+        },
+      )
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'payments' },
+        () => {
+          void refresh();
+        },
+      )
+      .subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [refresh]);
+
+  const handleCreateDebt = useCallback(
+    async (payload: CreateDebtPayload) => {
+      const debt = await createDebtMutation(payload);
+      await refresh();
+      return debt;
+    },
+    [refresh],
+  );
+
+  const handleRemoveDebt = useCallback(
+    async (debtId: string) => {
+      await removeDebtMutation(debtId);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  return {
+    rows,
+    loading,
+    refresh,
+    createDebt: handleCreateDebt,
+    removeDebt: handleRemoveDebt,
+  };
+};
+
+export default useDebts;

--- a/src/hooks/usePayments.ts
+++ b/src/hooks/usePayments.ts
@@ -1,0 +1,39 @@
+/**
+ * React hook for interacting with debt payment records.
+ */
+import { useCallback } from 'react';
+
+import type { AddPaymentPayload, Payment } from '../lib/db';
+import { addPayment as addPaymentMutation, listPayments } from '../lib/db';
+
+export interface UsePaymentsResult {
+  listPayments: (debtId: string) => Promise<Payment[]>;
+  addPayment: (payload: AddPaymentPayload) => Promise<Payment>;
+}
+
+const usePayments = (): UsePaymentsResult => {
+  const handleListPayments = useCallback(async (debtId: string) => {
+    if (!debtId) {
+      return [];
+    }
+
+    try {
+      return await listPayments(debtId);
+    } catch (error) {
+      console.error('Failed to load payments', error);
+      return [];
+    }
+  }, []);
+
+  const handleAddPayment = useCallback(
+    async (payload: AddPaymentPayload) => addPaymentMutation(payload),
+    [],
+  );
+
+  return {
+    listPayments: handleListPayments,
+    addPayment: handleAddPayment,
+  };
+};
+
+export default usePayments;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,270 @@
+/**
+ * Data access layer for Supabase Postgres.
+ *
+ * This module centralizes table/view typings and CRUD helpers used across the app.
+ */
+import type { User } from '@supabase/supabase-js';
+import supabase from './supabaseClient';
+
+export type MembershipType = 'free' | 'premium';
+export type DebtType =
+  | 'credit_card'
+  | 'auto_loan'
+  | 'student_loan'
+  | 'mortgage'
+  | 'personal_loan'
+  | 'medical_debt'
+  | 'other';
+export type DebtStatus = 'active' | 'paid_off' | 'closed';
+export type PaymentType = 'regular' | 'extra' | 'minimum' | 'final';
+export type ReminderType = 'due_date' | 'custom' | 'milestone' | 'strategy';
+export type StrategyType = 'snowball' | 'avalanche';
+
+export interface UserProfile {
+  id: string;
+  email: string;
+  name?: string | null;
+  membership_type: MembershipType;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Debt {
+  id: string;
+  user_id: string;
+  name: string;
+  balance: string;
+  original_amount: string;
+  interest_rate: string;
+  minimum_payment: string;
+  due_date: string | null;
+  debt_type: DebtType;
+  status: DebtStatus;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Payment {
+  id: string;
+  user_id: string;
+  debt_id: string;
+  amount: string;
+  payment_date: string;
+  payment_type: PaymentType;
+  notes: string | null;
+  created_at: string;
+}
+
+export interface VDebtProgress {
+  debt_id: string;
+  total_paid: string;
+  paid_percent: string;
+  remaining_balance?: string | null;
+  last_payment_date?: string | null;
+}
+
+export interface CreateDebtPayload {
+  name: string;
+  balance: number;
+  original_amount: number;
+  interest_rate: number;
+  minimum_payment: number;
+  due_date?: string | null;
+  debt_type: DebtType;
+  status?: DebtStatus;
+  notes?: string | null;
+}
+
+export interface UpdateDebtPayload {
+  id: string;
+  name?: string;
+  balance?: number;
+  original_amount?: number;
+  interest_rate?: number;
+  minimum_payment?: number;
+  due_date?: string | null;
+  debt_type?: DebtType;
+  status?: DebtStatus;
+  notes?: string | null;
+}
+
+export interface AddPaymentPayload {
+  debt_id: string;
+  amount: number;
+  payment_date: string;
+  payment_type: PaymentType;
+  notes?: string | null;
+}
+
+const handleError = (context: string, error: { message: string } | null) => {
+  if (error) {
+    throw new Error(`${context}: ${error.message}`);
+  }
+};
+
+const requireAuthUser = async (): Promise<User> => {
+  const { data, error } = await supabase.auth.getUser();
+  handleError('Failed to load authenticated user', error);
+
+  if (!data?.user) {
+    throw new Error('No authenticated user is available.');
+  }
+
+  return data.user;
+};
+
+export const upsertMyProfile = async (): Promise<UserProfile> => {
+  const user = await requireAuthUser();
+  if (!user.email) {
+    throw new Error('Authenticated user is missing an email address.');
+  }
+
+  const profilePayload = {
+    id: user.id,
+    email: user.email,
+    name:
+      (user.user_metadata?.full_name as string | undefined) ??
+      (user.user_metadata?.name as string | undefined) ??
+      null,
+  };
+
+  const { data, error } = await supabase
+    .from('user_profiles')
+    .upsert(profilePayload, { onConflict: 'id' })
+    .select()
+    .single();
+
+  handleError('Failed to upsert user profile', error);
+
+  if (!data) {
+    throw new Error('No profile data returned after upsert.');
+  }
+
+  return data as UserProfile;
+};
+
+export const listDebts = async (): Promise<Debt[]> => {
+  const { data, error } = await supabase
+    .from('debts')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  handleError('Failed to load debts', error);
+
+  return (data ?? []) as Debt[];
+};
+
+export const listDebtProgress = async (): Promise<VDebtProgress[]> => {
+  const { data, error } = await supabase
+    .from('v_debt_progress')
+    .select('*')
+    .order('debt_id', { ascending: true });
+
+  handleError('Failed to load debt progress', error);
+
+  return (data ?? []) as VDebtProgress[];
+};
+
+export const createDebt = async (payload: CreateDebtPayload): Promise<Debt> => {
+  const user = await requireAuthUser();
+
+  const { data, error } = await supabase
+    .from('debts')
+    .insert({
+      user_id: user.id,
+      name: payload.name,
+      balance: payload.balance,
+      original_amount: payload.original_amount,
+      interest_rate: payload.interest_rate,
+      minimum_payment: payload.minimum_payment,
+      due_date: payload.due_date ?? null,
+      debt_type: payload.debt_type,
+      status: payload.status ?? 'active',
+      notes: payload.notes ?? null,
+    })
+    .select()
+    .single();
+
+  handleError('Failed to create debt', error);
+
+  if (!data) {
+    throw new Error('No debt returned after creation.');
+  }
+
+  return data as Debt;
+};
+
+export const updateDebt = async (payload: UpdateDebtPayload): Promise<Debt> => {
+  const updates: Record<string, unknown> = {};
+
+  if (payload.name !== undefined) updates.name = payload.name;
+  if (payload.balance !== undefined) updates.balance = payload.balance;
+  if (payload.original_amount !== undefined)
+    updates.original_amount = payload.original_amount;
+  if (payload.interest_rate !== undefined)
+    updates.interest_rate = payload.interest_rate;
+  if (payload.minimum_payment !== undefined)
+    updates.minimum_payment = payload.minimum_payment;
+  if (payload.due_date !== undefined) updates.due_date = payload.due_date;
+  if (payload.debt_type !== undefined) updates.debt_type = payload.debt_type;
+  if (payload.status !== undefined) updates.status = payload.status;
+  if (payload.notes !== undefined) updates.notes = payload.notes;
+
+  const { data, error } = await supabase
+    .from('debts')
+    .update(updates)
+    .eq('id', payload.id)
+    .select()
+    .single();
+
+  handleError('Failed to update debt', error);
+
+  if (!data) {
+    throw new Error('No debt returned after update.');
+  }
+
+  return data as Debt;
+};
+
+export const removeDebt = async (debtId: string): Promise<void> => {
+  const { error } = await supabase.from('debts').delete().eq('id', debtId);
+  handleError('Failed to delete debt', error);
+};
+
+export const listPayments = async (debtId: string): Promise<Payment[]> => {
+  const { data, error } = await supabase
+    .from('payments')
+    .select('*')
+    .eq('debt_id', debtId)
+    .order('payment_date', { ascending: false });
+
+  handleError('Failed to load payments', error);
+
+  return (data ?? []) as Payment[];
+};
+
+export const addPayment = async (payload: AddPaymentPayload): Promise<Payment> => {
+  const user = await requireAuthUser();
+
+  const { data, error } = await supabase
+    .from('payments')
+    .insert({
+      user_id: user.id,
+      debt_id: payload.debt_id,
+      amount: payload.amount,
+      payment_date: payload.payment_date,
+      payment_type: payload.payment_type,
+      notes: payload.notes ?? null,
+    })
+    .select()
+    .single();
+
+  handleError('Failed to add payment', error);
+
+  if (!data) {
+    throw new Error('No payment returned after creation.');
+  }
+
+  return data as Payment;
+};

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,26 @@
+/**
+ * Supabase client initialization.
+ *
+ * The client is created using public environment variables exposed by Vite.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('Missing VITE_SUPABASE_URL environment variable.');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable.');
+}
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});
+
+export default supabase;

--- a/src/pages/AuthGate.tsx
+++ b/src/pages/AuthGate.tsx
@@ -1,0 +1,200 @@
+/**
+ * Authentication gate page.
+ *
+ * Provides email OTP and anonymous sign-in options, and ensures the
+ * authenticated user has a corresponding profile record.
+ */
+import { FormEvent, useEffect, useRef, useState } from 'react';
+
+import { upsertMyProfile } from '../lib/db';
+import supabase from '../lib/supabaseClient';
+import useAuth from '../hooks/useAuth';
+
+const AuthGate = (): JSX.Element => {
+  const { session, loading } = useAuth();
+  const [email, setEmail] = useState('');
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [profileSyncing, setProfileSyncing] = useState(false);
+  const syncedUserIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const syncProfile = async () => {
+      if (!session?.user?.id) return;
+      if (syncedUserIdRef.current === session.user.id) return;
+
+      setProfileSyncing(true);
+      try {
+        await upsertMyProfile();
+        syncedUserIdRef.current = session.user.id;
+        setStatusMessage('登入成功，使用者資料已同步。');
+        setErrorMessage(null);
+      } catch (err) {
+        console.error('Failed to sync user profile', err);
+        setErrorMessage('同步使用者資料時發生錯誤，請稍後再試。');
+      } finally {
+        setProfileSyncing(false);
+      }
+    };
+
+    void syncProfile();
+  }, [session]);
+
+  const handleEmailLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!email) {
+      setErrorMessage('請輸入電子郵件地址。');
+      return;
+    }
+
+    setActionLoading(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: {
+          emailRedirectTo: typeof window !== 'undefined' ? window.location.origin : undefined,
+        },
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      setStatusMessage('已寄出登入連結，請檢查電子郵件信箱。');
+    } catch (err) {
+      console.error('Email OTP sign-in failed', err);
+      setErrorMessage('寄送登入連結失敗，請稍後再試。');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleAnonymousLogin = async () => {
+    setActionLoading(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const { error } = await supabase.auth.signInAnonymously();
+      if (error) {
+        throw error;
+      }
+
+      setStatusMessage('已使用匿名模式登入。');
+    } catch (err) {
+      console.error('Anonymous sign-in failed', err);
+      setErrorMessage('匿名登入失敗，請稍後再試。');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleSignOut = async () => {
+    setActionLoading(true);
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    try {
+      const { error } = await supabase.auth.signOut();
+      if (error) {
+        throw error;
+      }
+      syncedUserIdRef.current = null;
+    } catch (err) {
+      console.error('Sign-out failed', err);
+      setErrorMessage('登出失敗，請稍後再試。');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50">
+        <p className="text-base text-slate-600">載入中…</p>
+      </div>
+    );
+  }
+
+  if (session) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 p-6">
+        <div className="w-full max-w-md space-y-4 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="space-y-1">
+            <h1 className="text-2xl font-semibold text-slate-900">歡迎回來！</h1>
+            <p className="text-sm text-slate-600">
+              已登入帳號：{session.user.email ?? '匿名使用者'}
+            </p>
+          </div>
+          {profileSyncing ? (
+            <p className="text-sm text-blue-600">同步使用者資料中…</p>
+          ) : null}
+          {statusMessage ? <p className="text-sm text-emerald-600">{statusMessage}</p> : null}
+          {errorMessage ? <p className="text-sm text-rose-600">{errorMessage}</p> : null}
+          <button
+            type="button"
+            onClick={handleSignOut}
+            disabled={actionLoading}
+            className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+          >
+            登出
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 p-6">
+      <div className="w-full max-w-md space-y-6 rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="space-y-1 text-center">
+          <h1 className="text-2xl font-semibold text-slate-900">登入 DebtWise</h1>
+          <p className="text-sm text-slate-600">選擇以下方式開始使用您的帳戶。</p>
+        </div>
+        <form className="space-y-3" onSubmit={handleEmailLogin}>
+          <label className="block text-left text-sm font-medium text-slate-700">
+            電子郵件
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="you@example.com"
+              className="mt-1 w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:outline-none focus:ring-1 focus:ring-slate-900"
+              required
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={actionLoading}
+            className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+          >
+            寄送 Email OTP 登入連結
+          </button>
+        </form>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-slate-400">
+            <span className="h-px flex-1 bg-slate-200" />
+            或
+            <span className="h-px flex-1 bg-slate-200" />
+          </div>
+          <button
+            type="button"
+            onClick={handleAnonymousLogin}
+            disabled={actionLoading}
+            className="w-full rounded-md border border-slate-900 px-4 py-2 text-sm font-medium text-slate-900 transition hover:bg-slate-900 hover:text-white disabled:cursor-not-allowed disabled:border-slate-400 disabled:text-slate-400"
+          >
+            匿名登入
+          </button>
+        </div>
+        {statusMessage ? <p className="text-sm text-center text-emerald-600">{statusMessage}</p> : null}
+        {errorMessage ? <p className="text-sm text-center text-rose-600">{errorMessage}</p> : null}
+      </div>
+    </div>
+  );
+};
+
+export default AuthGate;

--- a/src/pages/DebtDashboard.tsx
+++ b/src/pages/DebtDashboard.tsx
@@ -1,0 +1,348 @@
+/**
+ * Debt dashboard page that combines debt overview and creation utilities.
+ */
+import { FormEvent, useMemo, useState } from 'react';
+
+import useDebts from '../hooks/useDebts';
+import usePayments from '../hooks/usePayments';
+
+const currencyFormatter = new Intl.NumberFormat('zh-TW', {
+  style: 'currency',
+  currency: 'TWD',
+  maximumFractionDigits: 0,
+});
+
+const percentFormatter = new Intl.NumberFormat('zh-TW', {
+  style: 'percent',
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
+});
+
+const formatCurrency = (value: string | number | null | undefined): string => {
+  return currencyFormatter.format(Number(value ?? 0));
+};
+
+const formatPercent = (value: string | number | null | undefined): string => {
+  return percentFormatter.format(Number(value ?? 0));
+};
+
+const formatDate = (value: string | null | undefined): string => {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleDateString('zh-TW');
+};
+
+const DebtDashboard = (): JSX.Element => {
+  const { rows, loading, refresh, createDebt, removeDebt } = useDebts();
+  const { addPayment } = usePayments();
+
+  const [name, setName] = useState('');
+  const [originalAmount, setOriginalAmount] = useState<number | ''>('');
+  const [interestRate, setInterestRate] = useState<number | ''>('');
+  const [minimumPayment, setMinimumPayment] = useState<number | ''>('');
+  const [dueDate, setDueDate] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [formMessage, setFormMessage] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const orderedRows = useMemo(() => {
+    return [...rows].sort((a, b) => a.created_at.localeCompare(b.created_at));
+  }, [rows]);
+
+  const resetForm = () => {
+    setName('');
+    setOriginalAmount('');
+    setInterestRate('');
+    setMinimumPayment('');
+    setDueDate('');
+  };
+
+  const handleCreateDebt = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+    setFormMessage(null);
+
+    if (!name.trim()) {
+      setFormError('請輸入債務名稱。');
+      return;
+    }
+
+    if (originalAmount === '' || interestRate === '' || minimumPayment === '') {
+      setFormError('請完整填寫所有數值欄位。');
+      return;
+    }
+
+    if (interestRate < 0 || interestRate > 1) {
+      setFormError('利率必須介於 0 到 1 之間。');
+      return;
+    }
+
+    const originalAmountValue = Number(originalAmount);
+    const interestRateValue = Number(interestRate);
+    const minimumPaymentValue = Number(minimumPayment);
+
+    if (originalAmountValue <= 0 || minimumPaymentValue <= 0) {
+      setFormError('金額需大於 0。');
+      return;
+    }
+
+    setSubmitting(true);
+
+    try {
+      await createDebt({
+        name: name.trim(),
+        balance: originalAmountValue,
+        original_amount: originalAmountValue,
+        interest_rate: interestRateValue,
+        minimum_payment: minimumPaymentValue,
+        due_date: dueDate ? dueDate : null,
+        debt_type: 'other',
+      });
+      resetForm();
+      setFormMessage('已新增債務。');
+    } catch (error) {
+      console.error('Failed to create debt', error);
+      setFormError('新增債務時發生錯誤，請稍後再試。');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRecordPayment = async (debtId: string, debtName: string) => {
+    setActionMessage(null);
+    setActionError(null);
+
+    const input = window.prompt(`請輸入「${debtName}」的付款金額：`);
+    if (input === null) {
+      return;
+    }
+
+    const amount = Number(input);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setActionError('付款金額需為大於 0 的數字。');
+      return;
+    }
+
+    try {
+      await addPayment({
+        debt_id: debtId,
+        amount,
+        payment_date: new Date().toISOString(),
+        payment_type: 'regular',
+      });
+      setActionMessage('已新增付款紀錄。');
+      await refresh();
+    } catch (error) {
+      console.error('Failed to add payment', error);
+      setActionError('新增付款時發生錯誤，請稍後再試。');
+    }
+  };
+
+  const handleRemoveDebt = async (debtId: string, debtName: string) => {
+    setActionMessage(null);
+    setActionError(null);
+
+    const confirmed = window.confirm(`確定要刪除「${debtName}」嗎？此動作無法復原。`);
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await removeDebt(debtId);
+      setActionMessage('已刪除債務。');
+    } catch (error) {
+      console.error('Failed to remove debt', error);
+      setActionError('刪除債務時發生錯誤，請稍後再試。');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50 p-6">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <h1 className="text-2xl font-semibold text-slate-900">債務儀表板</h1>
+            <button
+              type="button"
+              onClick={() => {
+                setActionMessage(null);
+                setActionError(null);
+                void refresh();
+              }}
+              className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+            >
+              重新整理
+            </button>
+          </div>
+          <form className="grid gap-4 md:grid-cols-2" onSubmit={handleCreateDebt}>
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+              債務名稱
+              <input
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="例如：信用卡"
+                className="rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:outline-none focus:ring-1 focus:ring-slate-900"
+                required
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+              原始金額
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={originalAmount === '' ? '' : originalAmount}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setOriginalAmount(value === '' ? '' : Number(value));
+                }}
+                placeholder="例如：120000"
+                className="rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:outline-none focus:ring-1 focus:ring-slate-900"
+                required
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+              利率 (0-1)
+              <input
+                type="number"
+                min="0"
+                max="1"
+                step="0.001"
+                value={interestRate === '' ? '' : interestRate}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setInterestRate(value === '' ? '' : Number(value));
+                }}
+                placeholder="例如：0.18"
+                className="rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:outline-none focus:ring-1 focus:ring-slate-900"
+                required
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+              每月最低還款
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={minimumPayment === '' ? '' : minimumPayment}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setMinimumPayment(value === '' ? '' : Number(value));
+                }}
+                placeholder="例如：5000"
+                className="rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:outline-none focus:ring-1 focus:ring-slate-900"
+                required
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm font-medium text-slate-700 md:col-span-2 md:max-w-xs">
+              到期日
+              <input
+                type="date"
+                value={dueDate}
+                onChange={(event) => setDueDate(event.target.value)}
+                className="rounded-md border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:outline-none focus:ring-1 focus:ring-slate-900"
+              />
+            </label>
+            <div className="md:col-span-2">
+              <button
+                type="submit"
+                disabled={submitting}
+                className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:bg-slate-400"
+              >
+                {submitting ? '新增中…' : '新增債務'}
+              </button>
+              {formError ? (
+                <p className="mt-2 text-sm text-rose-600">{formError}</p>
+              ) : null}
+              {formMessage ? (
+                <p className="mt-2 text-sm text-emerald-600">{formMessage}</p>
+              ) : null}
+            </div>
+          </form>
+        </section>
+
+        <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="mb-4 space-y-1">
+            <h2 className="text-xl font-semibold text-slate-900">債務清單</h2>
+            <p className="text-sm text-slate-600">
+              顯示每筆債務的原始金額、目前餘額、累計付款與還款進度。
+            </p>
+          </div>
+          {actionError ? <p className="mb-3 text-sm text-rose-600">{actionError}</p> : null}
+          {actionMessage ? <p className="mb-3 text-sm text-emerald-600">{actionMessage}</p> : null}
+          {loading ? (
+            <p className="text-sm text-slate-600">資料載入中…</p>
+          ) : orderedRows.length === 0 ? (
+            <p className="text-sm text-slate-600">目前沒有債務資料。</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+                <thead className="bg-slate-100 text-xs uppercase tracking-wide text-slate-500">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">名稱</th>
+                    <th className="px-4 py-3 font-medium">原始金額</th>
+                    <th className="px-4 py-3 font-medium">目前餘額</th>
+                    <th className="px-4 py-3 font-medium">累計付款</th>
+                    <th className="px-4 py-3 font-medium">還款進度</th>
+                    <th className="px-4 py-3 font-medium">到期日</th>
+                    <th className="px-4 py-3 font-medium">操作</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-200">
+                  {orderedRows.map((row) => (
+                    <tr key={row.id}>
+                      <td className="px-4 py-3 text-slate-900">{row.name}</td>
+                      <td className="px-4 py-3 text-slate-700">
+                        {formatCurrency(row.original_amount)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-700">
+                        {formatCurrency(row.balance)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-700">
+                        {formatCurrency(row.total_paid)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-700">
+                        {formatPercent(row.paid_percent)}
+                      </td>
+                      <td className="px-4 py-3 text-slate-700">{formatDate(row.due_date)}</td>
+                      <td className="px-4 py-3 text-slate-700">
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            onClick={() => void handleRecordPayment(row.id, row.name)}
+                            className="rounded-md bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-500"
+                          >
+                            付款
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => void handleRemoveDebt(row.id, row.name)}
+                            className="rounded-md border border-rose-500 px-3 py-1.5 text-xs font-semibold text-rose-600 transition hover:bg-rose-50"
+                          >
+                            刪除
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default DebtDashboard;


### PR DESCRIPTION
## Summary
- add Supabase client factory configured by Vite environment variables
- define typed data models for Supabase tables and view interactions
- implement helpers for managing user profiles, debts, payments, and debt progress queries
- add React authentication hook that exposes the Supabase session state
- create AuthGate page with email OTP and anonymous sign-in flows that sync user profiles after login
- add debts hook that merges realtime Supabase updates with debt progress metrics and exposes CRUD helpers
- implement DebtDashboard page with debt creation form, formatted metrics, and payment/removal actions
- wire the root App component to show AuthGate for unauthenticated users and sync the profile before rendering the DebtDashboard when logged in

## Testing
- npm run build *(fails: vite executable not found because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d18bf5678c832eb9bd9c18f2d71202