### PR TITLE
Fix Supabase profile schema to drop email column

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -22,8 +22,7 @@ export type StrategyType = 'snowball' | 'avalanche';
 
 export interface UserProfile {
   id: string;
-  email: string;
-  name?: string | null;
+  full_name?: string | null;
   membership_type: MembershipType;
   created_at: string;
   updated_at: string;
@@ -116,21 +115,17 @@ const requireAuthUser = async (): Promise<User> => {
 
 export const upsertMyProfile = async (): Promise<UserProfile> => {
   const user = await requireAuthUser();
-  if (!user.email) {
-    throw new Error('Authenticated user is missing an email address.');
-  }
 
   const profilePayload = {
     id: user.id,
-    email: user.email,
-    name:
+    full_name:
       (user.user_metadata?.full_name as string | undefined) ??
       (user.user_metadata?.name as string | undefined) ??
       null,
   };
 
   const { data, error } = await supabase
-    .from('user_profiles')
+    .from('profiles')
     .upsert(profilePayload, { onConflict: 'id' })
     .select()
     .single();

--- a/src/services/mockSupabaseClient.ts
+++ b/src/services/mockSupabaseClient.ts
@@ -6,7 +6,7 @@ import type {
 } from '@supabase/supabase-js';
 import type { Debt, Payment, Reminder, UserProfile } from '../types/db';
 
-type MockUser = UserProfile & { password: string };
+type MockUser = UserProfile & { email: string; password: string };
 
 type MockData = {
   users: MockUser[];
@@ -56,7 +56,7 @@ const defaultData: MockData = {
     {
       id: defaultUserId,
       email: 'demo@debtwise.ai',
-      name: 'DebtWise Demo',
+      full_name: 'DebtWise Demo',
       membership_type: 'premium',
       created_at: now,
       updated_at: now,
@@ -270,7 +270,7 @@ function toAuthUser(user: MockUser) {
     id: user.id,
     email: user.email,
     app_metadata: { provider: 'email' },
-    user_metadata: { name: user.name },
+    user_metadata: { full_name: user.full_name, name: user.full_name },
     aud: 'authenticated',
     role: 'authenticated',
     created_at: user.created_at,
@@ -398,7 +398,7 @@ class MockSupabaseAuth {
       user = {
         id: generateId('mock-user'),
         email,
-        name: email,
+        full_name: email,
         membership_type: 'free',
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
@@ -426,7 +426,7 @@ class MockSupabaseAuth {
   }: {
     email: string;
     password: string;
-    options?: { data?: { name?: string } };
+    options?: { data?: { full_name?: string | null } };
   }): Promise<AuthResponse> {
     const existing = this.findUserByEmail(email);
 
@@ -437,10 +437,12 @@ class MockSupabaseAuth {
       } as unknown as AuthResponse;
     }
 
+    const fullName = options?.data?.full_name ?? null;
+
     const user: MockUser = {
       id: generateId('mock-user'),
       email,
-      name: options?.data?.name ?? email,
+      full_name: fullName ?? email,
       membership_type: 'free',
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),

--- a/src/services/supabaseClient.ts
+++ b/src/services/supabaseClient.ts
@@ -26,8 +26,7 @@ const getEnvVar = (key: string) => {
   return undefined;
 };
 
-const useMockSupabase =
-  (getEnvVar('VITE_SUPABASE_USE_MOCK') ?? getEnvVar('SUPABASE_USE_MOCK')) === 'true';
+const useMockSupabase = getEnvVar('VITE_SUPABASE_USE_MOCK') === 'true';
 
 let supabaseClient: Pick<SupabaseClient, 'auth' | 'from'>;
 
@@ -36,9 +35,8 @@ if (useMockSupabase) {
   console.info(`[supabaseClient] ${MOCK_SUPABASE_NOTICE}`);
   supabaseClient = createMockSupabaseClient();
 } else {
-  const supabaseUrl = getEnvVar('VITE_SUPABASE_URL') ?? getEnvVar('SUPABASE_URL');
-  const supabaseAnonKey =
-    getEnvVar('VITE_SUPABASE_ANON_KEY') ?? getEnvVar('SUPABASE_ANON_KEY');
+  const supabaseUrl = getEnvVar('VITE_SUPABASE_URL');
+  const supabaseAnonKey = getEnvVar('VITE_SUPABASE_ANON_KEY');
 
   if (!supabaseUrl) {
     throw new Error('Missing VITE_SUPABASE_URL environment variable.');

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -13,8 +13,7 @@ export type StrategyType = 'snowball' | 'avalanche';
 
 export interface UserProfile {
   id: string;
-  email: string;
-  name?: string;
+  full_name?: string | null;
   membership_type: MembershipType;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/20240709000000_create_profiles_table.sql
+++ b/supabase/migrations/20240709000000_create_profiles_table.sql
@@ -1,46 +1,86 @@
--- Create profiles table to store application-specific user data
-create extension if not exists "pgcrypto";
-create extension if not exists citext;
-
+-- Profiles table for application-specific user data without duplicating auth emails
 create table if not exists public.profiles (
-  id uuid primary key default gen_random_uuid(),
-  email citext unique not null,
-  password_hash text not null,
-  name text default '' not null,
-  income numeric default 0 not null,
-  expenses numeric default 0 not null,
+  id uuid primary key references auth.users(id) on delete cascade,
+  full_name text,
+  password_hash text,
+  income numeric not null default 0,
+  expenses numeric not null default 0,
   reminder_preferences jsonb not null default jsonb_build_object(
     'daysBeforeDue', 3,
     'timeOfDay', '09:00'
   ),
-  membership text not null default 'free' check (membership in ('free', 'premium')),
+  membership_type text not null default 'free' check (membership_type in ('free', 'premium')),
   created_at timestamptz not null default timezone('utc', now()),
   updated_at timestamptz not null default timezone('utc', now())
 );
 
-comment on table public.profiles is 'DebtWise user profiles with budgeting preferences and membership data.';
-
--- keep reminder preferences json schema minimal validation
+comment on table public.profiles is 'Application user profiles tied to auth.users.';
+comment on column public.profiles.full_name is 'Optional full name synced from auth metadata.';
 comment on column public.profiles.reminder_preferences is 'JSON blob storing reminder settings such as daysBeforeDue and timeOfDay.';
+
+-- Ensure legacy columns are aligned with the new schema
+alter table public.profiles drop column if exists email;
+
+alter table public.profiles add column if not exists full_name text;
+alter table public.profiles add column if not exists password_hash text;
+
+alter table public.profiles add column if not exists income numeric;
+alter table public.profiles alter column income set default 0;
+update public.profiles set income = 0 where income is null;
+alter table public.profiles alter column income set not null;
+
+alter table public.profiles add column if not exists expenses numeric;
+alter table public.profiles alter column expenses set default 0;
+update public.profiles set expenses = 0 where expenses is null;
+alter table public.profiles alter column expenses set not null;
+
+alter table public.profiles add column if not exists reminder_preferences jsonb;
+alter table public.profiles alter column reminder_preferences set default jsonb_build_object(
+  'daysBeforeDue', 3,
+  'timeOfDay', '09:00'
+);
+update public.profiles
+set reminder_preferences = jsonb_build_object('daysBeforeDue', 3, 'timeOfDay', '09:00')
+where reminder_preferences is null;
+alter table public.profiles alter column reminder_preferences set not null;
+
+alter table public.profiles add column if not exists membership_type text;
+update public.profiles
+set membership_type = 'free'
+where membership_type is null
+   or membership_type not in ('free', 'premium');
+alter table public.profiles alter column membership_type set default 'free';
+alter table public.profiles alter column membership_type set not null;
+alter table public.profiles drop constraint if exists profiles_membership_type_check;
+alter table public.profiles add constraint profiles_membership_type_check check (membership_type in ('free', 'premium'));
+
+alter table public.profiles add column if not exists created_at timestamptz;
+alter table public.profiles alter column created_at set default timezone('utc', now());
+update public.profiles set created_at = timezone('utc', now()) where created_at is null;
+alter table public.profiles alter column created_at set not null;
+
+alter table public.profiles add column if not exists updated_at timestamptz;
+alter table public.profiles alter column updated_at set default timezone('utc', now());
+update public.profiles set updated_at = timezone('utc', now()) where updated_at is null;
+alter table public.profiles alter column updated_at set not null;
 
 alter table public.profiles enable row level security;
 
-create policy "Service role full access" on public.profiles
-  using (auth.role() = 'service_role')
-  with check (auth.role() = 'service_role');
-
-create policy "Users can view own profile" on public.profiles
+drop policy if exists "Profiles are selectable by owners" on public.profiles;
+create policy "Profiles are selectable by owners" on public.profiles
   for select
-  using (auth.uid() = id);
+  using (auth.role() = 'service_role' or auth.uid() = id);
 
-create policy "Users can update own profile" on public.profiles
-  for update
-  using (auth.uid() = id)
-  with check (auth.uid() = id);
-
-create policy "Users can insert own profile" on public.profiles
+drop policy if exists "Profiles are insertable by owners" on public.profiles;
+create policy "Profiles are insertable by owners" on public.profiles
   for insert
-  with check (auth.uid() = id);
+  with check (auth.role() = 'service_role' or auth.uid() = id);
+
+drop policy if exists "Profiles are updatable by owners" on public.profiles;
+create policy "Profiles are updatable by owners" on public.profiles
+  for update
+  using (auth.role() = 'service_role' or auth.uid() = id)
+  with check (auth.role() = 'service_role' or auth.uid() = id);
 
 create or replace function public.handle_profiles_updated_at()
 returns trigger as $$
@@ -50,7 +90,32 @@ begin
 end;
 $$ language plpgsql;
 
+drop trigger if exists set_profiles_updated_at on public.profiles;
 create trigger set_profiles_updated_at
   before update on public.profiles
   for each row
   execute function public.handle_profiles_updated_at();
+
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.profiles (id, full_name)
+  values (
+    new.id,
+    coalesce(
+      new.raw_user_meta_data->>'full_name',
+      new.raw_user_meta_data->>'name'
+    )
+  )
+  on conflict (id) do update
+    set full_name = excluded.full_name,
+        updated_at = timezone('utc', now());
+  return new;
+end;
+$$ language plpgsql security definer set search_path = public;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row
+  execute function public.handle_new_user();


### PR DESCRIPTION
## Summary
- switch client-side sign-up to use Supabase `auth.signUp` with full name metadata, profile upsert, and password auth
- update shared profile typing and mock Supabase implementation to rely on `full_name` from the `profiles` table
- recreate the `profiles` migration with RLS policies plus `handle_new_user` trigger and ensure the browser client only reads VITE Supabase env vars
- align the Supabase database adapter and migration with the email-free schema by mapping profile fields to `full_name`/`membership_type` columns and preserving auth emails during updates

## Testing
- `npm install` *(fails: npm registry returns 403 for @supabase/supabase-js)*
- `npm test` *(fails: vitest binary unavailable because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ac9a53e0832e8b4ef3700ca5fa73