### PR TITLE
Refactor Supabase sign up flow and admin lookups

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,60 @@
+import type { AuthResponse } from '@supabase/supabase-js';
+
+import supabaseClient from './supabaseClient';
+
+export interface SignUpWithProfileParams {
+  email: string;
+  password: string;
+  fullName?: string;
+}
+
+const emailRedirectTo =
+  typeof window !== 'undefined' ? `${window.location.origin}/auth/callback` : undefined;
+
+export async function signUpWithProfile({
+  email,
+  password,
+  fullName,
+}: SignUpWithProfileParams): Promise<AuthResponse['data']> {
+  const { data, error } = await supabaseClient.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo,
+      data: { full_name: fullName ?? '' },
+    },
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  if (data.user) {
+    const { error: profileError } = await supabaseClient
+      .from('profiles')
+      .upsert(
+        { id: data.user.id, full_name: fullName ?? '' },
+        { onConflict: 'id' },
+      );
+
+    if (profileError) {
+      throw profileError;
+    }
+  }
+
+  return data;
+}
+
+export async function signInUser(email: string, password: string): Promise<AuthResponse['data']> {
+  const { data, error } = await supabaseClient.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+}
+
+export const supabase = supabaseClient;
+
+export default supabase;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -19,7 +19,7 @@ function createAuthService(context) {
     const password = getString(payload, 'password', { minLength: 8 });
     const name = getString(payload, 'name', { required: false, defaultValue: '' });
 
-    const existing = await db.getUserByEmail(email);
+    const existing = await db.findUserByEmail(email);
     if (existing) {
       throw new AppError(409, 'Email is already registered.');
     }
@@ -51,7 +51,7 @@ function createAuthService(context) {
   async function login(payload) {
     const email = ensureEmail(getString(payload, 'email', { minLength: 3 }));
     const password = getString(payload, 'password', { minLength: 8 });
-    const user = await db.getUserByEmail(email);
+    const user = await db.findUserByEmail(email);
     if (!user || !verifyPassword(password, user.passwordHash)) {
       throw new AppError(401, 'Invalid email or password.');
     }
@@ -77,7 +77,7 @@ function createAuthService(context) {
 
   async function requestPasswordReset(payload) {
     const email = ensureEmail(getString(payload, 'email', { minLength: 3 }));
-    const user = await db.getUserByEmail(email);
+    const user = await db.findUserByEmail(email);
     if (!user) {
       throw new AppError(404, 'User with provided email was not found.');
     }


### PR DESCRIPTION
## Summary
- add a dedicated `lib/auth` helper that wraps Supabase sign-up with profile upserts and sign-in
- update front-end sign-up/login flows and the shared API service to consume the new helpers with clearer error handling
- rename database email lookups to `findUserByEmail` and rely on the Supabase admin API on the server

## Testing
- `npm run lint` *(fails: ESLint missing plugin because npm install is blocked by registry 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2eaf4ea1c832e84d86c38764c5990