### PR TITLE
Fix Supabase admin lookup and registration error handling

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -207,11 +207,7 @@ class ApiService {
         }
 
         console.error('Supabase register error:', error);
-        // 回退到 API 端點
-        return this.request('/auth/register', {
-          method: 'POST',
-          body: userData,
-        });
+        throw new Error(message || '註冊失敗，請稍後再試。');
       }
     } else {
       return this.request('/auth/register', {


### PR DESCRIPTION
## Summary
- replace the deprecated `auth.admin.getUserByEmail` access with the supported `listUsers` lookup so Supabase admin requests work again
- stop the front-end registration service from falling back to the admin API and instead surface a friendly error message when sign up fails

## Testing
- `npm install` *(fails: registry access is blocked in the execution environment)*
- `npm run build` *(fails: vite executable unavailable because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f4f22220832ea2ce90c995570dce