### PR TITLE
Fix API base URL configuration for front/back connectivity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,10 @@ VITE_APP_TITLE="DebtWise AI - 智能債務管理系統"
 VITE_APP_DESCRIPTION="使用 AI 技術幫助您制定最佳還款策略"
 VITE_APP_VERSION="1.0.0"
 
-# API 配置（未來使用）
-# VITE_API_BASE_URL=https://api.debtwise.ai
+# API 配置
+VITE_API_BASE_URL="/api"
+# 亦支援舊的 VITE_API_URL 變數，若需指定不同網域請填入完整 URL：
+# VITE_API_URL="https://api.debtwise.ai"
 # VITE_API_TIMEOUT=10000
 
 # Supabase 配置

--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ npm run preview
 npm run test
 ```
 
+## 🔌 前後端連線配置
+
+- **預設行為**：前端會呼叫與網站同網域的 `/api`，適用於本地開發（Vite 代理）與 Vercel 等部署環境。
+- **環境變數**：
+  - `VITE_API_BASE_URL`（建議）或 `VITE_API_URL`（相容用）可覆寫 API 位置。
+  - 若需指向外部後端，請設定完整的網址，例如 `https://api.example.com`。
+- **備註**：環境變數中的網址會自動移除結尾的 `/`，避免產生 `//api` 之類的錯誤路徑。
+
 ## 🔧 後端設定（Supabase）
 
 後端 API 預設會連線至 Supabase PostgreSQL。請在部署或啟動 Serverless Functions 時設定以下環境變數：

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,4 +1,7 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+const resolvedApiBaseUrl =
+  import.meta.env.VITE_API_BASE_URL ?? import.meta.env.VITE_API_URL ?? '/api';
+
+const API_BASE_URL = resolvedApiBaseUrl.replace(/\/+$/, '') || '/api';
 
 class ApiError extends Error {
   constructor(message, status, details) {

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -8,6 +8,13 @@ import { signInUser, signUpWithProfile } from '@/lib/auth';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
+const resolveApiBaseUrl = () => {
+  const envBaseUrl =
+    import.meta.env.VITE_API_URL ?? import.meta.env.VITE_API_BASE_URL ?? '/api';
+  const sanitized = envBaseUrl.replace(/\/+$/, '');
+  return sanitized || '/api';
+};
+
 // 檢查是否使用真實 API
 const useRealAPI = () => {
   return (
@@ -25,7 +32,7 @@ if (useRealAPI()) {
 // API 服務類
 class ApiService {
   constructor() {
-    this.baseURL = import.meta.env.VITE_API_URL || 'https://debtwise-ai.vercel.app/api';
+    this.baseURL = resolveApiBaseUrl();
     this.useReal = useRealAPI();
   }
 


### PR DESCRIPTION
## Summary
- normalize API base URL resolution so the frontend defaults to the same-origin `/api` endpoint
- allow both `VITE_API_BASE_URL` and legacy `VITE_API_URL` variables and strip trailing slashes before requests
- document the connection variables in `.env.example` and the README so the frontend/back-end link is explicit

## Testing
- npm install *(fails: 403 Forbidden when downloading packages in the execution environment)*
- npm run lint *(fails without local ESLint install because npm install could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68d327051fbc832e8bd0e16a108b2d0d